### PR TITLE
Add system-based dark mode support

### DIFF
--- a/mediscribe_app/lib/core/color.dart
+++ b/mediscribe_app/lib/core/color.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
 class AppColors {
+  // ========== Light Theme Colors ==========
+  
   // Primary brand color (Mediscribe blue)
   static const Color primary = Color(0xFF1E3A8A);
 
@@ -14,4 +16,22 @@ class AppColors {
   // UI elements
   static const Color button = Color(0xFF1E40AF);
   static const Color border = Color(0xFFE5E7EB);
+
+  // ========== Dark Theme Colors ==========
+  
+  // Primary brand color for dark mode (lighter blue for better contrast)
+  static const Color darkPrimary = Color(0xFF60A5FA);
+
+  // Background
+  static const Color darkBackground = Color(0xFF0F172A);
+  static const Color darkSurface = Color(0xFF1E293B);
+
+  // Text
+  static const Color darkTextPrimary = Color(0xFFF1F5F9);
+  static const Color darkTextSecondary = Color(0xFF94A3B8);
+
+  // UI elements
+  static const Color darkButton = Color(0xFF3B82F6);
+  static const Color darkBorder = Color(0xFF334155);
+  static const Color darkCardBackground = Color(0xFF1E293B);
 }

--- a/mediscribe_app/lib/core/text_styles.dart
+++ b/mediscribe_app/lib/core/text_styles.dart
@@ -1,17 +1,17 @@
 import 'package:flutter/material.dart';
-import 'package:mediscribe_app/core/color.dart';
 
 class AppTextStyles {
-  static const TextStyle heroTitle = TextStyle(
+  // Use Theme.of(context) colors for dynamic theme support
+  static TextStyle heroTitle(BuildContext context) => TextStyle(
     fontSize: 28,
     fontWeight: FontWeight.bold,
-    color: AppColors.textPrimary,
+    color: Theme.of(context).colorScheme.onSurface,
     height: 1.3,
   );
 
-  static const TextStyle subtitle = TextStyle(
+  static TextStyle subtitle(BuildContext context) => TextStyle(
     fontSize: 16,
-    color: AppColors.textSecondary,
+    color: Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
     height: 1.5,
   );
 
@@ -21,9 +21,26 @@ class AppTextStyles {
     color: Colors.white,
   );
 
-  static const TextStyle sectionTitle = TextStyle(
+  static TextStyle sectionTitle(BuildContext context) => TextStyle(
     fontSize: 18,
     fontWeight: FontWeight.w600,
-    color: AppColors.textPrimary,
+    color: Theme.of(context).colorScheme.onSurface,
+  );
+
+  // Legacy static styles (kept for backward compatibility)
+  static const TextStyle heroTitleStatic = TextStyle(
+    fontSize: 28,
+    fontWeight: FontWeight.bold,
+    height: 1.3,
+  );
+
+  static const TextStyle subtitleStatic = TextStyle(
+    fontSize: 16,
+    height: 1.5,
+  );
+
+  static const TextStyle sectionTitleStatic = TextStyle(
+    fontSize: 18,
+    fontWeight: FontWeight.w600,
   );
 }

--- a/mediscribe_app/lib/core/theme.dart
+++ b/mediscribe_app/lib/core/theme.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:mediscribe_app/core/color.dart';
+
+class AppTheme {
+  // Light Theme
+  static ThemeData lightTheme = ThemeData(
+    brightness: Brightness.light,
+    scaffoldBackgroundColor: AppColors.background,
+    useMaterial3: true,
+    primaryColor: AppColors.primary,
+    colorScheme: const ColorScheme.light(
+      primary: AppColors.primary,
+      secondary: AppColors.button,
+      surface: Colors.white,
+      error: Color(0xFFDC2626),
+    ),
+    appBarTheme: const AppBarTheme(
+      backgroundColor: AppColors.background,
+      elevation: 0,
+      iconTheme: IconThemeData(color: AppColors.textPrimary),
+      titleTextStyle: TextStyle(
+        color: AppColors.primary,
+        fontWeight: FontWeight.bold,
+        fontSize: 22,
+      ),
+    ),
+    inputDecorationTheme: InputDecorationTheme(
+      filled: true,
+      fillColor: Colors.white,
+      hintStyle: TextStyle(color: AppColors.textSecondary.withOpacity(0.5)),
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: const BorderSide(color: AppColors.border),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: const BorderSide(color: AppColors.border),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: const BorderSide(color: AppColors.primary, width: 2),
+      ),
+    ),
+    cardTheme: CardThemeData(
+      color: Colors.white,
+      elevation: 2,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+    ),
+    elevatedButtonTheme: ElevatedButtonThemeData(
+      style: ElevatedButton.styleFrom(
+        backgroundColor: AppColors.button,
+        foregroundColor: Colors.white,
+        elevation: 0,
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+        ),
+      ),
+    ),
+  );
+
+  // Dark Theme
+  static ThemeData darkTheme = ThemeData(
+    brightness: Brightness.dark,
+    scaffoldBackgroundColor: AppColors.darkBackground,
+    useMaterial3: true,
+    primaryColor: AppColors.darkPrimary,
+    colorScheme: const ColorScheme.dark(
+      primary: AppColors.darkPrimary,
+      secondary: AppColors.darkButton,
+      surface: AppColors.darkSurface,
+      error: Color(0xFFEF4444),
+    ),
+    appBarTheme: const AppBarTheme(
+      backgroundColor: AppColors.darkBackground,
+      elevation: 0,
+      iconTheme: IconThemeData(color: AppColors.darkTextPrimary),
+      titleTextStyle: TextStyle(
+        color: AppColors.darkPrimary,
+        fontWeight: FontWeight.bold,
+        fontSize: 22,
+      ),
+    ),
+    inputDecorationTheme: InputDecorationTheme(
+      filled: true,
+      fillColor: AppColors.darkSurface,
+      hintStyle: TextStyle(color: AppColors.darkTextSecondary.withOpacity(0.5)),
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: const BorderSide(color: AppColors.darkBorder),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: const BorderSide(color: AppColors.darkBorder),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: const BorderSide(color: AppColors.darkPrimary, width: 2),
+      ),
+    ),
+    cardTheme: CardThemeData(
+      color: AppColors.darkSurface,
+      elevation: 2,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+    ),
+    elevatedButtonTheme: ElevatedButtonThemeData(
+      style: ElevatedButton.styleFrom(
+        backgroundColor: AppColors.darkButton,
+        foregroundColor: Colors.white,
+        elevation: 0,
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+        ),
+      ),
+    ),
+    popupMenuTheme: PopupMenuThemeData(
+      color: AppColors.darkSurface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+    ),
+  );
+}

--- a/mediscribe_app/lib/main.dart
+++ b/mediscribe_app/lib/main.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 import 'screens/login_screen.dart';
-import 'package:mediscribe_app/core/color.dart';
+import 'package:mediscribe_app/core/theme.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -18,10 +18,9 @@ class MediscribeApp extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'Mediscribe',
-      theme: ThemeData(
-        scaffoldBackgroundColor: AppColors.background,
-        useMaterial3: true,
-      ),
+      theme: AppTheme.lightTheme,
+      darkTheme: AppTheme.darkTheme,
+      themeMode: ThemeMode.system, // Automatically switch based on system settings
       home: const LoginScreen(), // ✅ LOGIN FIRST
     );
   }

--- a/mediscribe_app/lib/screens/home_screen.dart
+++ b/mediscribe_app/lib/screens/home_screen.dart
@@ -11,14 +11,14 @@ class HomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: AppColors.background,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       appBar: AppBar(
-        backgroundColor: AppColors.background,
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
         elevation: 0,
-        title: const Text(
+        title: Text(
           'Mediscribe',
           style: TextStyle(
-            color: AppColors.primary,
+            color: Theme.of(context).colorScheme.primary,
             fontWeight: FontWeight.bold,
             fontSize: 22,
           ),
@@ -60,20 +60,20 @@ class HomeScreen extends StatelessWidget {
             Container(
               padding: const EdgeInsets.all(20),
               decoration: BoxDecoration(
-                color: AppColors.primary.withOpacity(0.05),
+                color: Theme.of(context).colorScheme.primary.withOpacity(0.1),
                 borderRadius: BorderRadius.circular(16),
               ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
-                children: const [
+                children: [
                   Text(
                     'AI-powered solution for effortless\nprescription documentation',
-                    style: AppTextStyles.heroTitle,
+                    style: AppTextStyles.heroTitle(context),
                   ),
-                  SizedBox(height: 12),
+                  const SizedBox(height: 12),
                   Text(
                     'Upload medical prescriptions and instantly convert them into readable digital text using AI.',
-                    style: AppTextStyles.subtitle,
+                    style: AppTextStyles.subtitle(context),
                   ),
                 ],
               ),
@@ -97,9 +97,9 @@ class HomeScreen extends StatelessWidget {
             const SizedBox(height: 36),
 
             // ⭐ FEATURES TITLE
-            const Text(
+            Text(
               'Why Mediscribe?',
-              style: AppTextStyles.sectionTitle,
+              style: AppTextStyles.sectionTitle(context),
             ),
 
             const SizedBox(height: 16),
@@ -114,35 +114,39 @@ class HomeScreen extends StatelessWidget {
   }
 
   Widget _featureItem(IconData icon, String text) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 10),
-      child: Row(
-        children: [
-          Container(
-            width: 36,
-            height: 36,
-            decoration: BoxDecoration(
-              color: AppColors.primary.withOpacity(0.1),
-              borderRadius: BorderRadius.circular(8),
-            ),
-            child: Icon(
-              icon,
-              size: 20,
-              color: AppColors.primary,
-            ),
-          ),
-          const SizedBox(width: 14),
-          Expanded(
-            child: Text(
-              text,
-              style: const TextStyle(
-                fontSize: 15,
-                color: AppColors.textSecondary,
+    return Builder(
+      builder: (context) {
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 10),
+          child: Row(
+            children: [
+              Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.primary.withOpacity(0.1),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(
+                  icon,
+                  size: 20,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
               ),
-            ),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Text(
+                  text,
+                  style: TextStyle(
+                    fontSize: 15,
+                    color: Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
+                  ),
+                ),
+              ),
+            ],
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 }

--- a/mediscribe_app/lib/screens/login_screen.dart
+++ b/mediscribe_app/lib/screens/login_screen.dart
@@ -9,7 +9,7 @@ class LoginScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: AppColors.background,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(24),
@@ -19,31 +19,31 @@ class LoginScreen extends StatelessWidget {
               const SizedBox(height: 40),
 
               // 👋 Welcome Text
-              const Text(
+              Text(
                 'Welcome back',
                 style: TextStyle(
                   fontSize: 28,
                   fontWeight: FontWeight.bold,
-                  color: AppColors.textPrimary,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
               ),
               const SizedBox(height: 6),
-              const Text(
+              Text(
                 "Let's get you started.",
                 style: TextStyle(
                   fontSize: 15,
-                  color: AppColors.textSecondary,
+                  color: Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
                 ),
               ),
 
               const SizedBox(height: 40),
 
               // 📧 Email
-              const Text(
+              Text(
                 'Email',
                 style: TextStyle(
                   fontSize: 13,
-                  color: AppColors.textSecondary,
+                  color: Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
                 ),
               ),
               const SizedBox(height: 6),
@@ -61,19 +61,19 @@ class LoginScreen extends StatelessWidget {
               // 🔒 Password + Forgot
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: const [
+                children: [
                   Text(
                     'Password',
                     style: TextStyle(
                       fontSize: 13,
-                      color: AppColors.textSecondary,
+                      color: Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
                     ),
                   ),
                   Text(
                     'Forgot Password ?',
                     style: TextStyle(
                       fontSize: 13,
-                      color: AppColors.primary,
+                      color: Theme.of(context).colorScheme.primary,
                       fontWeight: FontWeight.w500,
                     ),
                   ),
@@ -109,18 +109,18 @@ class LoginScreen extends StatelessWidget {
 
               // ➖ OR Divider
               Row(
-                children: const [
-                  Expanded(child: Divider()),
+                children: [
+                  const Expanded(child: Divider()),
                   Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 12),
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
                     child: Text(
                       'Or',
                       style: TextStyle(
-                        color: AppColors.textSecondary,
+                        color: Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
                       ),
                     ),
                   ),
-                  Expanded(child: Divider()),
+                  const Expanded(child: Divider()),
                 ],
               ),
 
@@ -134,15 +134,15 @@ class LoginScreen extends StatelessWidget {
                   'https://upload.wikimedia.org/wikipedia/commons/0/09/IOS_Google_icon.png',
                   height: 18,
                 ),
-                label: const Text(
+                label: Text(
                   'Login with Google',
                   style: TextStyle(
-                    color: AppColors.textPrimary,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
                 ),
                 style: OutlinedButton.styleFrom(
                   minimumSize: const Size(double.infinity, 52),
-                  side: const BorderSide(color: AppColors.border),
+                  side: BorderSide(color: Theme.of(context).colorScheme.onSurface.withOpacity(0.2)),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12),
                   ),
@@ -154,17 +154,17 @@ class LoginScreen extends StatelessWidget {
               // 🆕 Sign Up Text
               Center(
                 child: RichText(
-                  text: const TextSpan(
-                    style: TextStyle(fontSize: 14),
+                  text: TextSpan(
+                    style: const TextStyle(fontSize: 14),
                     children: [
                       TextSpan(
                         text: "Don't have an account ? ",
-                        style: TextStyle(color: AppColors.textSecondary),
+                        style: TextStyle(color: Theme.of(context).colorScheme.onSurface.withOpacity(0.7)),
                       ),
                       TextSpan(
                         text: 'Sign Up',
                         style: TextStyle(
-                          color: AppColors.primary,
+                          color: Theme.of(context).colorScheme.primary,
                           fontWeight: FontWeight.w600,
                         ),
                       ),

--- a/mediscribe_app/lib/screens/processing_screen.dart
+++ b/mediscribe_app/lib/screens/processing_screen.dart
@@ -58,7 +58,7 @@ class _ProcessingScreenState extends State<ProcessingScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: AppColors.background,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -72,11 +72,11 @@ class _ProcessingScreenState extends State<ProcessingScreen> {
                       size: 72,
                       color: Colors.green,
                     )
-                  : const Icon(
+                  : Icon(
                       Icons.health_and_safety_rounded,
-                      key: ValueKey('loading'),
+                      key: const ValueKey('loading'),
                       size: 72,
-                      color: AppColors.primary,
+                      color: Theme.of(context).colorScheme.primary,
                     ),
             ),
 

--- a/mediscribe_app/lib/screens/result_screen.dart
+++ b/mediscribe_app/lib/screens/result_screen.dart
@@ -33,7 +33,7 @@ class ResultScreen extends StatelessWidget {
         text: '$word ',
         style: TextStyle(
           fontSize: 15,
-          color: isMedicine ? Colors.blueAccent : AppColors.textPrimary,
+          color: isMedicine ? Colors.blueAccent : null,
           fontWeight: isMedicine ? FontWeight.w600 : FontWeight.normal,
         ),
       );
@@ -48,7 +48,7 @@ class ResultScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: AppColors.background,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       appBar: AppBar(
         title: const Text('Prescription Result'),
       ),
@@ -58,16 +58,16 @@ class ResultScreen extends StatelessWidget {
           children: [
             // 🩺 Header
             Row(
-              children: const [
+              children: [
                 Icon(Icons.medical_services,
-                    color: AppColors.primary, size: 28),
-                SizedBox(width: 8),
+                    color: Theme.of(context).colorScheme.primary, size: 28),
+                const SizedBox(width: 8),
                 Text(
                   'Extracted Medical Data',
                   style: TextStyle(
                     fontSize: 18,
                     fontWeight: FontWeight.bold,
-                    color: AppColors.primary,
+                    color: Theme.of(context).colorScheme.primary,
                   ),
                 ),
               ],
@@ -81,9 +81,9 @@ class ResultScreen extends StatelessWidget {
                 width: double.infinity,
                 padding: const EdgeInsets.all(16),
                 decoration: BoxDecoration(
-                  color: Colors.white,
+                  color: Theme.of(context).colorScheme.surface,
                   borderRadius: BorderRadius.circular(14),
-                  border: Border.all(color: AppColors.border),
+                  border: Border.all(color: Theme.of(context).colorScheme.onSurface.withOpacity(0.2)),
                 ),
                 child: SingleChildScrollView(
                   child: RichText(

--- a/mediscribe_app/lib/screens/upload_screen.dart
+++ b/mediscribe_app/lib/screens/upload_screen.dart
@@ -74,7 +74,7 @@ class _UploadScreenState extends State<UploadScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: AppColors.background,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       appBar: AppBar(
         title: const Text('Upload Prescription'),
       ),
@@ -87,18 +87,18 @@ class _UploadScreenState extends State<UploadScreen> {
               height: 220,
               width: double.infinity,
               decoration: BoxDecoration(
-                color: Colors.white,
+                color: Theme.of(context).colorScheme.surface,
                 borderRadius: BorderRadius.circular(14),
-                border: Border.all(color: AppColors.border),
+                border: Border.all(color: Theme.of(context).colorScheme.onSurface.withOpacity(0.2)),
               ),
               child: _loadingImage
                   ? const Center(child: CircularProgressIndicator())
                   : _selectedImage == null
-                      ? const Center(
+                      ? Center(
                           child: Text(
                             'No image selected',
                             style: TextStyle(
-                              color: AppColors.textSecondary,
+                              color: Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
                             ),
                           ),
                         )

--- a/mediscribe_app/lib/widgets/feature_card.dart
+++ b/mediscribe_app/lib/widgets/feature_card.dart
@@ -20,9 +20,9 @@ class FeatureCard extends StatelessWidget {
       margin: const EdgeInsets.only(bottom: 12),
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        border: Border.all(color: AppColors.border),
+        border: Border.all(color: Theme.of(context).colorScheme.onSurface.withOpacity(0.2)),
         borderRadius: BorderRadius.circular(12),
-        color: Colors.white,
+        color: Theme.of(context).colorScheme.surface,
       ),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -30,12 +30,12 @@ class FeatureCard extends StatelessWidget {
           Container(
             padding: const EdgeInsets.all(10),
             decoration: BoxDecoration(
-              color: AppColors.primary.withOpacity(0.1),
+              color: Theme.of(context).colorScheme.primary.withOpacity(0.1),
               borderRadius: BorderRadius.circular(10),
             ),
             child: Icon(
               icon,
-              color: AppColors.primary,
+              color: Theme.of(context).colorScheme.primary,
               size: 22,
             ),
           ),
@@ -46,12 +46,12 @@ class FeatureCard extends StatelessWidget {
               children: [
                 Text(
                   title,
-                  style: AppTextStyles.sectionTitle,
+                  style: AppTextStyles.sectionTitle(context),
                 ),
                 const SizedBox(height: 6),
                 Text(
                   description,
-                  style: AppTextStyles.subtitle,
+                  style: AppTextStyles.subtitle(context),
                 ),
               ],
             ),

--- a/mediscribe_app/lib/widgets/primary_button.dart
+++ b/mediscribe_app/lib/widgets/primary_button.dart
@@ -23,8 +23,9 @@ class PrimaryButton extends StatelessWidget {
       child: ElevatedButton(
         onPressed: disabled ? null : onPressed,
         style: ElevatedButton.styleFrom(
-          backgroundColor:
-              disabled ? AppColors.border : AppColors.button,
+          backgroundColor: disabled
+              ? Theme.of(context).colorScheme.onSurface.withOpacity(0.2)
+              : Theme.of(context).colorScheme.secondary,
           padding: const EdgeInsets.symmetric(vertical: 14),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(10),


### PR DESCRIPTION
### What this PR does
- Adds dark mode support using ThemeMode.system
- App automatically switches based on device theme
- Updates UI components to use theme-aware colors

### What was NOT changed
- No business logic
- No API or backend logic
- No navigation or state changes

### How to test
1. Run the app
2. Switch system theme between light and dark
3. Verify UI adapts correctly

Fixes #<issue-number>
<img width="1287" height="981" alt="Screenshot 2026-01-05 181003" src="https://github.com/user-attachments/assets/ecc02381-04a3-4ab3-8d54-c430ef378316" />
<img width="1285" height="981" alt="Screenshot 2026-01-05 180929" src="https://github.com/user-attachments/assets/bff25c46-191b-40b7-9d9c-1297e1cbbdf9" />

